### PR TITLE
Changed search maximum to 50, sorted video list by published date

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.ytchannels" name="YouTube Channels" version="0.2.2+matrix.1" provider-name="natko1412,mintsoft,yeahme49">
+<addon id="plugin.video.ytchannels" name="YouTube Channels" version="0.2.3+matrix.1" provider-name="natko1412,mintsoft,yeahme49">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
 		<import addon="script.module.six" version="1.11.0"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,9 @@
 ===============================
 Youtube Channels addon by yeahme49/mintsoft/natko1412
 ===============================
+v0.2.3 [11-July-2020]
+-Changed search maximum to 50
+-Sorted the videos list by published date
 
 v0.2.2 [11-July-2020]
 -Video duration and description now provided on the listing page

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -17,9 +17,9 @@
 					<level>0</level>
 					<default>20</default>
 					<constraints>
-						<minimum>10</minimum>
+						<minimum>5</minimum>
 						<step>5</step>
-						<maximum>100</maximum>
+						<maximum>50</maximum>
 					</constraints>
 					<control type="slider" format="integer">
 						<popup>false</popup>
@@ -29,9 +29,9 @@
 					<level>0</level>
 					<default>20</default>
 					<constraints>
-						<minimum>10</minimum>
+						<minimum>5</minimum>
 						<step>5</step>
-						<maximum>100</maximum>
+						<maximum>50</maximum>
 					</constraints>
 					<control type="slider" format="integer">
 						<popup>false</popup>


### PR DESCRIPTION
When searching for channels and also listing the videos in a channel, the youtube api only allows a max of 50 results for query so i set the max to 50. also sorting videos by publishedAt. I noticed that in most cases videos are sorted newest to oldest, but if multiple videos are uploaded per day, it will list them oldest to newest for that day, then go onto the next day.